### PR TITLE
Issue： fix  chat historical data acquisition exception

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:authing_sdk_v3/authing.dart';
+import 'package:authing_sdk_v3/client.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
@@ -149,10 +150,10 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
   @override
   void initState() {
+    super.initState();
     NotificationUtil.initializeNotificationsEventListeners();
     NotificationUtil.initializeIsolateReceivePort();
     WidgetsBinding.instance.addObserver(this);
-    super.initState();
   }
 
   void _deinit() {
@@ -292,24 +293,26 @@ class DeciderWidget extends StatefulWidget {
 class _DeciderWidgetState extends State<DeciderWidget> {
   @override
   void initState() {
+    super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (context.read<ConnectivityProvider>().isConnected) {
         NotificationService.instance.saveNotificationToken();
       }
-
       if (context.read<AuthenticationProvider>().user != null) {
         context.read<HomeProvider>().setupHasSpeakerProfile();
         await Intercom.instance.loginIdentifiedUser(
-          userId: FirebaseAuth.instance.currentUser!.uid,
+          userId: AuthClient.currentUser?.id,
         );
+
         context.read<MessageProvider>().setMessagesFromCache();
         context.read<PluginProvider>().setPluginsFromCache();
         context.read<MessageProvider>().refreshMessages();
       } else {
+        
         await Intercom.instance.loginUnidentifiedUser();
       }
     });
-    super.initState();
+    
   }
 
   @override

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -177,7 +177,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       dialogStyle: Platform.isIOS ? UpgradeDialogStyle.cupertino : UpgradeDialogStyle.material,
       child: Consumer<ConnectivityProvider>(builder: (ctx, connectivityProvider, child) {
         bool isConnected = connectivityProvider.isConnected;
-        previousConnection ??= true;
+        previousConnection ??= false;
         if (previousConnection != isConnected) {
           previousConnection = isConnected;
           if (!isConnected) {

--- a/app/lib/providers/connectivity_provider.dart
+++ b/app/lib/providers/connectivity_provider.dart
@@ -6,7 +6,7 @@ import 'package:friend_private/generated/l10n.dart';
 
 class ConnectivityProvider extends ChangeNotifier {
   bool _isConnected = true;
-  bool _previousConnection = true;
+  bool _previousConnection = false;
   final InternetConnection _internetConnection = InternetConnection();
 
   bool get isConnected => _isConnected;


### PR DESCRIPTION
## Problem description

The chat history cannot be obtained in the application

## Cause of the problem
there are two problems here：
1. Join Connectivity Provider optimization is introduced in https://github.com/BasedHardware/omi/pull/733，it uses  variable `connectivityProvider.isConnected` and local variable `previousConnection` to manage whether the message needs to be pulled. This is a nice optimization that synchronizes data only when the network connection changes. But, their default values are the same，so that code will never be executed.

2. data synchronization is also performed during program initialization, but there is something wrong with the order in which `super.initState()` is called, `WidgetsBinding.instance.addPostFrameCallback` is not executed properly

**Official flutter documentation**
> If you override this, make sure your method starts with a call to super.initState().

